### PR TITLE
[Internal] Add completion handler to present(in:language:)

### DIFF
--- a/Deprecator/Source/Models/Deprecation.swift
+++ b/Deprecator/Source/Models/Deprecation.swift
@@ -40,7 +40,7 @@ public struct Deprecation: Decodable
     
     // MARK: Alerts
     
-    public func present(in viewController: UIViewController, language: String? = nil)
+    public func present(in viewController: UIViewController, language: String? = nil, completion: (() -> Void)? = nil)
     {
         var languageStrings = self.defaultLanguageStrings
         if let unwrappedLanguage = language,
@@ -66,7 +66,7 @@ public struct Deprecation: Decodable
         }
         
         // Present
-        viewController.present(alertController, animated: true, completion: nil)
+        viewController.present(alertController, animated: true, completion: completion)
     }
 }
 


### PR DESCRIPTION
Allow client to have its own completion handler when presenting Deprecation alert