### PR TITLE
[Bug] Prevent present function from being called from background thread

### DIFF
--- a/Deprecator/Source/Models/Deprecation.swift
+++ b/Deprecator/Source/Models/Deprecation.swift
@@ -66,7 +66,9 @@ public struct Deprecation: Decodable
         }
         
         // Present
-        viewController.present(alertController, animated: true, completion: nil)
+        DispatchQueue.main.async {
+            viewController.present(alertController, animated: true, completion: nil)
+        }
     }
 }
 


### PR DESCRIPTION
On iOS 13, calling the present(_:animated:completion:) function will cause a crash if
called in the background thread, so we have to make sure it is called from the main thread.